### PR TITLE
Fix fatal error during activation callback

### DIFF
--- a/wp-openapi.php
+++ b/wp-openapi.php
@@ -197,8 +197,7 @@ $wpOpenAPI = new WPOpenAPI();
 register_activation_hook(
 	__FILE__,
 	function () use ( $wpOpenAPI ) {
-		$wpOpenAPI->registerRoutes();
-		flush_rewrite_rules();
+		define( 'WP_OPENAPI_ACTIVATION', true );
 	}
 );
 
@@ -209,6 +208,10 @@ add_action(
 	'init',
 	function() use ( $wpOpenAPI ) {
 		$wpOpenAPI->registerRoutes();
+
+		if ( defined( 'WP_OPENAPI_ACTIVATION' ) ) {
+			flush_rewrite_rules();
+		}
 	}
 );
 add_action( 'rest_api_init', array( $wpOpenAPI, 'registerRestAPIEndpoint' ) );


### PR DESCRIPTION
* Don't register routes in activation callback.
* In order for `flush_rewrite_rules()` to only be called once when plugin is activated, set `WP_OPENAPI_ACTIVATION` constant in activation callback and then flush rewrite rules inside init callback only when its defined.

Fixes #14