### PR TITLE
Use option to determine to flush rewrites

### DIFF
--- a/wp-openapi.php
+++ b/wp-openapi.php
@@ -197,7 +197,7 @@ $wpOpenAPI = new WPOpenAPI();
 register_activation_hook(
 	__FILE__,
 	function () use ( $wpOpenAPI ) {
-		define( 'WP_OPENAPI_ACTIVATION', true );
+		update_option( 'wp-openapi-rewrite-flushed', false );
 	}
 );
 
@@ -209,8 +209,9 @@ add_action(
 	function() use ( $wpOpenAPI ) {
 		$wpOpenAPI->registerRoutes();
 
-		if ( defined( 'WP_OPENAPI_ACTIVATION' ) ) {
+		if ( !get_option( 'wp-openapi-rewrite-flushed' ) ) {
 			flush_rewrite_rules();
+			update_option( 'wp-openapi-rewrite-flushed', true );
 		}
 	}
 );


### PR DESCRIPTION
This is a follow-up PR for https://github.com/moon0326/wp-openapi/pull/15

Line https://github.com/moon0326/wp-openapi/pull/15  did not detect `WP_OPENAPI_ACTIVATION` although the code looked good. It looks like there might be a timing issue.

This PR uses `wp-openapi-rewrite-flushed` option to flush rewrite rules.