### PR TITLE
ADD: URL rest url prefix rest_get_url_prefix()

### DIFF
--- a/src/SchemaGenerator.php
+++ b/src/SchemaGenerator.php
@@ -53,7 +53,7 @@ class SchemaGenerator {
 			'openapi'    => '3.1.0',
 			'info'       => $this->generateInfo( $hookArgs )->toArray(),
 			'servers'    => array(
-				new Server( $this->siteInfo['siteurl'] . '/wp-json' ),
+				new Server( $this->siteInfo['siteurl'] . '/' . rest_get_url_prefix() ),
 			),
 			'tags'       => array(),
 			'security'   => array(),


### PR DESCRIPTION
I change the URL to Retrieves the URL prefix for any API resource. BuildIn fonction from Wordpress [4.4.0](https://developer.wordpress.org/reference/since/4.4.0/)

https://developer.wordpress.org/reference/functions/rest_get_url_prefix/