### PR TITLE
Fix: use home_url() instead of site_url() 

### DIFF
--- a/wp-openapi.php
+++ b/wp-openapi.php
@@ -168,9 +168,9 @@ class WPOpenAPI {
 		$permalink_structure = get_option( 'permalink_structure' );
 		$namespace           = $this->getNamespace();
 		if ( $permalink_structure === '' ) {
-			$endpoint = site_url( '?rest_route=/wp-openapi/v1/schema&namespace=' . $namespace );
+			$endpoint = home_url( '?rest_route=/wp-openapi/v1/schema&namespace=' . $namespace );
 		} else {
-			$endpoint = site_url( '/wp-json-openapi?namespace=' . $namespace );
+			$endpoint = home_url( '/wp-json-openapi?namespace=' . $namespace );
 		}
 
 		$data = array(


### PR DESCRIPTION
When WP is installed in a sub-dir, home_url() should be used to make the API request.