### PR TITLE
Support format=json to export json only

### DIFF
--- a/src/CLI/ExportAsJSON.php
+++ b/src/CLI/ExportAsJSON.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WPOpenAPI\CLI;
+
+use WPOpenAPI;
+use WPOpenAPI\Filters;
+use WPOpenAPI\SchemaGenerator;
+
+class ExportAsJSON {
+
+	public function execute( $namespace, $saveTo ) {
+		global $wp_version;
+		$siteInfo        = array(
+			'admin_email'     => get_option( 'admin_email' ),
+			'blogname'        => get_option( 'blogname' ),
+			'blogdescription' => get_option( 'blogdescription' ),
+			'home'            => get_option( 'home' ),
+			'wp_version'      => $wp_version,
+		);
+		$schemaGenerator = new SchemaGenerator( Filters::getInstance(), $siteInfo, rest_get_server() );
+		file_put_contents( $saveTo, json_encode($schemaGenerator->generate( $namespace ), JSON_PRETTY_PRINT) );
+
+		\WP_CLI::success( "Generated {$saveTo}" );
+	}
+}

--- a/wp-openapi.php
+++ b/wp-openapi.php
@@ -19,6 +19,7 @@
  */
 
 use WPOpenAPI\CLI\ExportAsHTML;
+use WPOpenAPI\CLI\ExportAsJSON;
 use WPOpenAPI\Filters;
 use WPOpenAPI\Filters\AddCallbackInfoToDescription;
 use WPOpenAPI\SchemaGenerator;
@@ -233,6 +234,14 @@ add_action(
 			function ( $args, $assoc_args ) {
 				$namespace = $assoc_args['namespace'];
 				$saveTo    = $assoc_args['save_to'];
+				$format    = $assoc_args['format'];
+
+				if ( $format === 'json' ) {
+					$command = new ExportAsJSON();
+					$command->execute( $namespace, $saveTo );
+					return;
+				}
+
 				$command   = new ExportAsHTML();
 				$command->execute( $namespace, $saveTo );
 			},
@@ -248,6 +257,13 @@ add_action(
 						'type'     => 'assoc',
 						'optional' => false,
 					),
+					array(
+						'name'     => 'format',
+						'type'     => 'assoc',
+						'optional' => true,
+						'default'  => 'html',
+						'options'  => array( 'html', 'json' ),
+					)
 				),
 			)
 		);


### PR DESCRIPTION
This PR adds a new export option `format` to support exporting JSON file without HTML and viewer.