### PR TITLE
Bump version to 1.0.11

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: documentation, rest api, api, openapi, swagger
 Requires at least: 5.8
 Tested up to: 6.0
 Requires PHP: 7.1
-Stable tag: 1.0.10
+Stable tag: 1.0.11
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/wp-openapi.php
+++ b/wp-openapi.php
@@ -9,7 +9,7 @@
  *
  * Plugin Name: WP OpenAPI
  * Plugin URI: https://github.com/moon0326/wp-openapi
- * Version:     1.0.10
+ * Version:     1.0.11
  * Author:      Moon K
  * Author URI: https://github.com/moon0326
  * License:     GPL v2 or later


### PR DESCRIPTION
Bump version to 1.0.11

Includes the following PRs:

- https://github.com/moon0326/wp-openapi/pull/38
- https://github.com/moon0326/wp-openapi/pull/36
