### PR TITLE
Use site_url() for the API request endpoint

### DIFF
--- a/wp-openapi.php
+++ b/wp-openapi.php
@@ -169,9 +169,9 @@ class WPOpenAPI {
 		$permalink_structure = get_option( 'permalink_structure' );
 		$namespace           = $this->getNamespace();
 		if ( $permalink_structure === '' ) {
-			$endpoint = home_url( '?rest_route=/wp-openapi/v1/schema&namespace=' . $namespace );
+			$endpoint = site_url( '?rest_route=/wp-openapi/v1/schema&namespace=' . $namespace );
 		} else {
-			$endpoint = home_url( '/wp-json-openapi?namespace=' . $namespace );
+			$endpoint = site_url( '/wp-json-openapi?namespace=' . $namespace );
 		}
 
 		$data = array(


### PR DESCRIPTION
Addresses #44 

Uses site_url() instead of home_url() for the API endpoint.