### PR TITLE
Remove rewrite rules -- use rest endpoint instead

### DIFF
--- a/wp-openapi.php
+++ b/wp-openapi.php
@@ -43,11 +43,6 @@ class WPOpenAPI {
 		return plugin_dir_url( __FILE__ ) . $path;
 	}
 
-	public function registerRoutes() {
-		add_rewrite_tag( '%openapi%', '([^&]+)' );
-		add_rewrite_rule( '^' . 'wp-json-openapi/?', 'index.php?openapi=schema', 'top' );
-	}
-
 	public function registerRestAPIEndpoint() {
 		register_rest_route(
 			'wp-openapi/v1',
@@ -166,13 +161,8 @@ class WPOpenAPI {
 			$infoJs['version']
 		);
 
-		$permalink_structure = get_option( 'permalink_structure' );
-		$namespace           = $this->getNamespace();
-		if ( $permalink_structure === '' ) {
-			$endpoint = site_url( '?rest_route=/wp-openapi/v1/schema&namespace=' . $namespace );
-		} else {
-			$endpoint = site_url( '/wp-json-openapi?namespace=' . $namespace );
-		}
+		$namespace	= $this->getNamespace();
+		$endpoint 	= add_query_arg( 'namespace', $namespace, rest_url( 'wp-openapi/v1/schema' ) );
 
 		$data = array(
 			'options'  => array(
@@ -195,27 +185,7 @@ class WPOpenAPI {
 
 $wpOpenAPI = new WPOpenAPI();
 
-register_activation_hook(
-	__FILE__,
-	function () use ( $wpOpenAPI ) {
-		update_option( 'wp-openapi-rewrite-flushed', false );
-	}
-);
-
-register_deactivation_hook( __FILE__, 'flush_rewrite_rules' );
-
 add_action( 'admin_menu', array( $wpOpenAPI, 'addAdminMenu' ) );
-add_action(
-	'init',
-	function() use ( $wpOpenAPI ) {
-		$wpOpenAPI->registerRoutes();
-
-		if ( !get_option( 'wp-openapi-rewrite-flushed' ) ) {
-			flush_rewrite_rules();
-			update_option( 'wp-openapi-rewrite-flushed', true );
-		}
-	}
-);
 add_action( 'rest_api_init', array( $wpOpenAPI, 'registerRestAPIEndpoint' ) );
 add_action(
 	'wp',

--- a/wp-openapi.php
+++ b/wp-openapi.php
@@ -161,8 +161,7 @@ class WPOpenAPI {
 			$infoJs['version']
 		);
 
-		$namespace	= $this->getNamespace();
-		$endpoint 	= add_query_arg( 'namespace', $namespace, rest_url( 'wp-openapi/v1/schema' ) );
+		$endpoint 	= add_query_arg( 'namespace', $this->getNamespace(), rest_url( 'wp-openapi/v1/schema' ) );
 
 		$data = array(
 			'options'  => array(


### PR DESCRIPTION
This PR replaces /wp-json-openapi endpoint with the rest api endpoint (/wp-json/wp-openapi/v1/schema)

Fixes #44 
