### PR TITLE
Update/restrict public endpoint

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,8 @@ WP OpenAPI has the following filters to modify the output.
 | wp-openapi-filter-security   |                 Array                 | AddSecurityFilter         |
 | wp-oepnapi-filter-components |                 Array                 | AddComponentsFilter       |
 | wp-openapi-filters-elements-props | Array||
+| wp-openapi-filters-schema-endpoint-permission | true||
+
 You can use individual filters by calling [add_filter](https://developer.wordpress.org/reference/functions/add_filter/).
 
 You can also use [Filters](./src/Filters.php).

--- a/resources/scripts/wp-openapi.js
+++ b/resources/scripts/wp-openapi.js
@@ -6,8 +6,6 @@ import { API } from "@stoplight/elements";
 import "@stoplight/elements/styles.min.css";
 
 const elementsAppContainer = document.getElementById("elements-app");
-
-
 const { fetch: originalFetch } = window;
 
 window.fetch = (resource, config) => {
@@ -22,9 +20,9 @@ window.fetch = (resource, config) => {
   if (
     resource.indexOf("wp-json") !== false &&
     config?.headers &&
-    config.headers["X-WP-Nonce"] === undefined
+    config.headers.get('X-WP-Nonce') === null
   ) {
-    config.headers["X-WP-Nonce"] = window.wpOpenApi.nonce;
+	config.headers.set("X-WP-Nonce", window.wpOpenApi.nonce);
   }
 
   return originalFetch( resource, config );

--- a/wp-openapi.php
+++ b/wp-openapi.php
@@ -50,7 +50,7 @@ class WPOpenAPI {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $this, 'sendOpenAPISchema' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => apply_filters( Filters::PREFIX . 'filter-schema-endpoint-permission', '__return_true' ),
 				'args'                => array(
 					'namespace' => array(
 						'type' => 'string',


### PR DESCRIPTION
This PR adds `wp-openapi-filters-schema-endpoint-permission` filter to control the public schema endpoint visibility and fixes a bug with X-WP-Nonce. 