### PR TITLE
Support multiple security entries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -112,6 +112,7 @@ register_rest_route(
 	)
 );
 
+
 ```
 
 ## Export

--- a/readme.md
+++ b/readme.md
@@ -38,16 +38,15 @@ It comes in handy if you want to look at the source code of the endpoint.
 
 WP OpenAPI has the following filters to modify the output.
 
-| Name                         |               Argument                | Equivalent Filters Method |
-| ---------------------------- | :-----------------------------------: | ------------------------- |
-| wp-openapi-filter-operations  | [Operation[]](./src/Spec/Operation.php) | AddOperationsFilter        |
-| wp-openapi-filter-paths       |      [Path[]](./src/Spec/Path.php)      | AddPathsFilter             |
-| wp-openapi-filter-servers     |    [Server[]](./src/Spec/Server.php)    | AddServersFilter           |
-| wp-openapi-filter-info       |      [Info](./src/Spec/Info.php)      | AddInfoFilter             |
-| wp-openapi-filter-tags        |       [Tag[]](./src/Spec/Tag.php)        | AddTagsFilter              |
-| wp-openapi-filter-security   |                 Array                 | AddSecurityFilter         |
-| wp-oepnapi-filter-components |                 Array                 | AddComponentsFilter       |
-| wp-openapi-filters-elements-props | Array||
+| Name                                          |               Argument                | Equivalent Filters Method |
+|-----------------------------------------------| :-----------------------------------: | ------------------------- |
+| wp-openapi-filter-operations                  | [Operation[]](./src/Spec/Operation.php) | AddOperationsFilter        |
+| wp-openapi-filter-paths                       |      [Path[]](./src/Spec/Path.php)      | AddPathsFilter             |
+| wp-openapi-filter-servers                     |    [Server[]](./src/Spec/Server.php)    | AddServersFilter           |
+| wp-openapi-filter-info                        |      [Info](./src/Spec/Info.php)      | AddInfoFilter             |
+| wp-openapi-filter-tags                        |       [Tag[]](./src/Spec/Tag.php)        | AddTagsFilter              |
+| wp-openapi-filter-components                  |                 Array                 | AddComponentsFilter       |
+| wp-openapi-filters-elements-props             | Array||
 | wp-openapi-filters-schema-endpoint-permission | true||
 
 You can use individual filters by calling [add_filter](https://developer.wordpress.org/reference/functions/add_filter/).

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ WP OpenAPI has the following filters to modify the output.
 | wp-openapi-filter-paths                       |      [Path[]](./src/Spec/Path.php)      | AddPathsFilter             |
 | wp-openapi-filter-servers                     |    [Server[]](./src/Spec/Server.php)    | AddServersFilter           |
 | wp-openapi-filter-info                        |      [Info](./src/Spec/Info.php)      | AddInfoFilter             |
-| wp-openapi-filter-tags                        |       [Tag[]](./src/Spec/Tag.php)        | AddTagsFilter              |
+| wp-openapi-filter-tags                        |       [Tag[]](./src/Spec/Tag.php)        | AddTagsFilter              |****
 | wp-openapi-filter-components                  |                 Array                 | AddComponentsFilter       |
 | wp-openapi-filters-elements-props             | Array||
 | wp-openapi-filters-schema-endpoint-permission | true||
@@ -63,6 +63,55 @@ Filters::getInstance()->addPathsFilter(function(array $paths, array $args) {
         }
     }
 });
+```
+
+## Using security field
+
+Since there is no central place to add `securitySchemes` in WordPress, you can use the `wp-openapi-filter-components` filter to add them.
+
+```
+ add_filter('wp-openapi-filter-components', function(array $components) {
+	$components['securitySchemes'] = [
+		'api_key' => [
+			'type' => 'apiKey',
+			'name' => 'api_key',
+			'in' => 'header',
+		]
+	];
+	
+	return $components;
+ });
+```
+Now, you can use the `security` field in your REST API definition.
+
+```
+register_rest_route(
+	$this->namespace,
+	'/' . $this->rest_base . '/test',
+	array(
+		array(
+			'methods'             => 'GET',
+			'callback'            => array( $this, 'test' ),
+			'args'                => array(
+				'status' => array(
+					'type' => 'string',
+					'enum' => array( 'yes', 'no' ),
+				),
+				'credentials' => [
+					'type' => 'object',
+					'properties' => [
+						'username' => ['type' => 'string'],
+						'application_password' => ['type' => 'string'],
+					]
+				]
+			),
+			'security' => array(
+				'api_key'=> array(),
+			)
+		),
+	)
+);
+
 ```
 
 ## Export

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Filters::getInstance()->addPathsFilter(function(array $paths, array $args) {
 
 Since there is no central place to add `securitySchemes` in WordPress, you can use the `wp-openapi-filter-components` filter to add them.
 
-```
+```php
  add_filter('wp-openapi-filter-components', function(array $components) {
 	$components['securitySchemes'] = [
 		'api_key' => [
@@ -84,7 +84,7 @@ Since there is no central place to add `securitySchemes` in WordPress, you can u
 ```
 Now, you can use the `security` field in your REST API definition.
 
-```
+```php
 register_rest_route(
 	$this->namespace,
 	'/' . $this->rest_base . '/test',

--- a/src/Filters.php
+++ b/src/Filters.php
@@ -107,24 +107,6 @@ class Filters {
 	}
 
 	/**
-	 * @param array $security
-	 * @param array $args
-	 * @return array
-	 */
-	public function applySecurityFilters( array $security, array $args = array() ): array {
-		return apply_filters( self::PREFIX . 'filter-security', $security, $args );
-	}
-
-	/**
-	 * @param $callback
-	 * @param int      $priority
-	 * @return bool|true|void
-	 */
-	public function addSecurityFilter( $callback, int $priority = 10 ) {
-		return add_filter( self::PREFIX . 'filter-security', $callback, $priority, 2 );
-	}
-
-	/**
 	 * @param Tag[] $tags
 	 * @param array $args
 	 * @return Tag[]

--- a/src/SchemaGenerator.php
+++ b/src/SchemaGenerator.php
@@ -56,7 +56,6 @@ class SchemaGenerator {
 				new Server( $this->siteInfo['home'] . '/' . rest_get_url_prefix() ),
 			),
 			'tags'       => array(),
-			'security'   => array(),
 			'components' => array(
 				'schemas' => array(),
 			),
@@ -104,7 +103,6 @@ class SchemaGenerator {
 		);
 
 		$base['components'] = $this->hooks->applyComponentsFilters( $base['components'], $hookArgs );
-		$base['security']   = $this->hooks->applySecurityFilters( $base['security'], $hookArgs );
 
 		return $base;
 	}

--- a/src/Spec/Operation.php
+++ b/src/Spec/Operation.php
@@ -43,7 +43,7 @@ class Operation {
 		'minProperties'        => array( 'location' => 'root' ),
 		'maxProperties'        => array( 'location' => 'root' ),
 		'enum'                 => array( 'location' => 'root' ),
-        	'properties'           => array( 'location' => 'root' ),
+        'properties'           => array( 'location' => 'root' ),
 	);
 
 	public function __construct( string $method, array $responses ) {
@@ -98,9 +98,9 @@ class Operation {
 		$this->operationId = $operationId;
 	}
 
-	public function addSecurity( $security ) {
-		$this->securities[] = $security;
-	}
+    public function addSecurity( $name, $values ): void {
+        $this->securities[] = (object) array( $name => $values );
+    }
 
 	public function toArray(): array {
 		$data = array(
@@ -136,12 +136,9 @@ class Operation {
 			);
 		}
 
-		if ( $this->securities ) {
-			$data['security'] = array();
-			foreach ( $this->securities as $security ) {
-				$data['security'][] = array( $security => array() );
-			}
-		}
+        if ( $this->securities ) {
+            $data['security'] = $this->securities;
+        }
 
 		if ( count( $this->requestBodySchemaProperties ) ) {
 			$schema = array(

--- a/src/Spec/Path.php
+++ b/src/Spec/Path.php
@@ -77,6 +77,11 @@ class Path {
 				$op          = new Operation( $method, $responses );
 				$op->setDescription( $description );
 				$op->generateParametersFromRouteArgs( $method, $arg['args'], $this->pathVariables, $this->path );
+                if ( isset( $arg['security']) && is_array( $arg['security'] ) ) {
+                    foreach ( $arg['security'] as $name => $values) {
+                        $op->addSecurity( $name, $values );
+                    }
+                }
 				$this->operations[] = $op;
 			}
 		}


### PR DESCRIPTION
Fixes #60 

- Added an example to add `components.securitySchemes` and using `security` in a REST API definition.
- Updated code to support multiple security entries