### PR TITLE
Make sure required field is bool

### DIFF
--- a/src/Spec/Operation.php
+++ b/src/Spec/Operation.php
@@ -253,7 +253,11 @@ class Operation {
 				$values['description'] = '';
 			}
 
-			if ( ! isset( $values['required'] ) ) {
+			// monkey patch for invalid $values['required'].
+			// make sure it is a boolean.
+			// We don't have a full control over what other plugins 
+			// are passing to us. So we need to be careful.
+			if ( ! isset( $values['required'] ) || ! is_bool( $values['required'] ) ) {
 				$values['required'] = false;
 			}
 


### PR DESCRIPTION
Fix for #67 

Some plugins can set an incorrect values for REST API def and WP won't bother to block it :)

Make sure `required` field is a bool. 