### PR TITLE
Fix schema validation

### DIFF
--- a/src/Spec/Operation.php
+++ b/src/Spec/Operation.php
@@ -3,6 +3,7 @@
 namespace WPOpenAPI\Spec;
 
 use InvalidArgumentException;
+use WPOpenAPI\Util;
 
 class Operation {
 	const METHODS            = array( 'get', 'post', 'patch', 'delete', 'put' );
@@ -157,6 +158,20 @@ class Operation {
 				$schema['required'] = $requiredProperties;
 			}
 
+			$schema = Util::removeArrayKeysRecursively( $schema, array( 'context', 'readonly' ) );
+			Util::modifyArrayValueByKeyRecursive($schema, 'type', function($type) {
+				return Util::normalzieInvalidType($type);
+			});
+
+			Util::modifyPropertiesRecursive($schema, function($properties) {
+				foreach ($properties as $key => $property) {
+					if (isset($property['required'])) {
+						unset($properties[$key]['required']);
+					}
+				}
+				return $properties;
+			});
+
 			$data['requestBody'] = array(
 				'content' => array(
 					'application/x-www-form-urlencoded' => array(
@@ -238,6 +253,9 @@ class Operation {
 	public function generateParametersFromRouteArgs( $method, array $args, array $pathVariables, $endpoint ): void {
 		// get, method, delete, put
 		foreach ( $args as $name => $values ) {
+			if (isset($values['context'])) {
+				$values = Util::removeArrayKeysRecursively( $values, array( 'context', 'readonly' ) );
+			}
 			if ( in_array( $name, $pathVariables ) ) {
 				$in = 'path';
 				// required must be set to true when the in value is 'path'
@@ -265,6 +283,8 @@ class Operation {
 				$values['type'] = 'string';
 			}
 
+			$values['type'] = Util::normalzieInvalidType( $values['type'] );
+
 			$parameter = new Parameter( $in, $name, $values['type'], $values['description'], $values['required'] );
 			if ( isset( $values['default'] ) ) {
 				$parameter->setDefault( $values['default'] );
@@ -275,7 +295,7 @@ class Operation {
 				if ( in_array( $key, $supportedJsonSchemaSets ) ) {
 					$parameter->addJsonSchemaDefinition( $key, $value, $this->jsonSchemaSets[ $key ]['location'] );
 				}
-			}
+			}     
 
 			$this->parameters[] = $parameter;
 		}

--- a/src/Spec/Parameter.php
+++ b/src/Spec/Parameter.php
@@ -3,6 +3,7 @@
 namespace WPOpenAPI\Spec;
 
 use InvalidArgumentException;
+use WPOpenAPI\Util;
 
 class Parameter {
 
@@ -66,6 +67,11 @@ class Parameter {
 				} else {
 					$data['schema']->$key = $values['value'];
 				}
+			}
+			// Try to clean up duplicate values added by mistake by plugins.
+			// Enum must be unique.
+			if ( isset( $data['schema']->enum ) ) {
+				$data['schema']->enum = array_unique($data['schema']->enum);
 			}
 		}
 		return $data;

--- a/src/Util.php
+++ b/src/Util.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace WPOpenAPI;
+
+class Util {
+	public static function removeArrayKeysRecursively( array $array, array $keysToRemove ): array {
+		foreach ($array as $key => &$value) {
+			if (in_array($key, $keysToRemove, true)) {
+				unset($array[$key]);
+			} elseif (is_array($value)) {
+				$value = self::removeArrayKeysRecursively($value, $keysToRemove);
+			}
+		}
+
+		return $array;
+	}
+
+	public static function modifyArrayValueByKeyRecursive(array &$array, $key, callable $callback): void {
+		foreach ($array as $k => &$v) {
+			if ($k === $key) {
+				$v = $callback($v);
+			}
+
+			if (is_array($v)) {
+				self::modifyArrayValueByKeyRecursive($v, $key, $callback);
+			}
+		}
+	}
+
+	public static function modifyPropertiesRecursive(array &$array, callable $callback): void {
+		foreach ($array as $key => &$value) {
+			if ($key === 'properties') {
+				$value = $callback($value);
+			}
+
+			if (is_array($value)) {
+				self::modifyPropertiesRecursive($value, $callback);
+			}
+		}
+	}
+
+
+	/**
+	 * In WordPress, some schema formats are not compatible with the OpenAPI specification.
+	 * This function converts those special or non-standard types to OpenAPI-compatible values.
+	 * These values should not be used as 'type' values according to JSON Schema,
+	 * but are sometimes used in WordPress REST API schemas regardless.
+	*/
+	public static function normalzieInvalidType( $type ) {
+		if ( is_array( $type ) ) {
+			foreach ( $type as $key => $value ) {
+				$type[ $key ] = self::normalzieInvalidType( $value );
+			}
+			return $type;
+		}
+
+		$replacements = array(
+			'date' => 'string',
+			'date-time' => 'string',
+			'email' => 'string',
+			'hostname' => 'string',
+			'ipv4' => 'string',
+			'uri' => 'string',
+			'mixed' => 'string',
+			'bool' => 'boolean',
+		);
+
+		if ( isset( $replacements[ $type ] ) ) {
+			return $replacements[ $type ];
+		}
+
+		return $type;
+	}
+}


### PR DESCRIPTION
Closes #68 

- Removes context and readonly from components -- these are WP specific
- Remove required from the property level -- it should be in the object level
- Normalize `type` value