### PR TITLE
feat(acf): generate acf fields on openapi file

### DIFF
--- a/src/Filters/AddACFSchema.php
+++ b/src/Filters/AddACFSchema.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace WPOpenAPI\Filters;
+
+use WPOpenAPI\Filters;
+use WP_REST_Server;
+use WP_REST_Request;
+
+class AddACFSchema {
+	private Filters $hooks;
+	private WP_REST_Server $restServer;
+	private array $schemaCache = array();
+
+	public function __construct( Filters $hooks, WP_REST_Server $restServer ) {
+		$this->hooks      = $hooks;
+		$this->restServer = $restServer;
+
+		$this->hooks->addComponentsFilter( array( $this, 'augmentComponentsWithACF' ), 10 );
+		$this->hooks->addOperationsFilter( array( $this, 'augmentOperationsWithACF' ), 10 );
+	}
+
+	/**
+	 * Fetch ACF schema for a given route via OPTIONS request
+	 *
+	 * @param string $route The REST API route
+	 * @return array|null The ACF schema if found, null otherwise
+	 */
+	protected function fetchACFSchema( string $route ): ?array {
+		// Check cache first
+		if ( isset( $this->schemaCache[ $route ] ) ) {
+			return $this->schemaCache[ $route ];
+		}
+
+		// Perform OPTIONS request to get schema
+		$request  = new WP_REST_Request( 'OPTIONS', $route );
+		$response = rest_do_request( $request );
+
+		if ( is_wp_error( $response ) || $response->get_status() !== 200 ) {
+			$this->schemaCache[ $route ] = null;
+			return null;
+		}
+
+		$data = $response->get_data();
+
+		// Check if ACF schema exists in the response
+		if ( isset( $data['schema']['properties']['acf'] ) ) {
+			$acfSchema = $data['schema']['properties']['acf'];
+			
+			// Normalize the ACF schema to ensure all properties have types
+			$acfSchema = $this->normalizeACFSchema( $acfSchema );
+			
+			$this->schemaCache[ $route ] = $acfSchema;
+			return $acfSchema;
+		}
+
+		$this->schemaCache[ $route ] = null;
+		return null;
+	}
+
+	/**
+	 * Normalize ACF schema to ensure all properties have valid types
+	 * This handles clone fields and other ACF field types that might not include explicit types
+	 *
+	 * @param array $schema The ACF schema to normalize
+	 * @return array The normalized schema
+	 */
+	protected function normalizeACFSchema( array $schema ): array {
+		// Ensure the schema has a type
+		if ( ! isset( $schema['type'] ) && isset( $schema['properties'] ) ) {
+			$schema['type'] = 'object';
+		}
+
+		// Convert exact-match patterns to enums for better TypeScript support
+		// This enables type narrowing in openapi-typescript for discriminator fields like acf_fc_layout
+		if ( isset( $schema['pattern'] ) && is_string( $schema['pattern'] ) ) {
+			// Match patterns like ^value$ (exact string match)
+			if ( preg_match( '/^\^(.+)\$$/', $schema['pattern'], $matches ) ) {
+				$value = $matches[1];
+				// Convert to enum array
+				$schema['enum'] = array( $value );
+				// Remove the pattern property
+				unset( $schema['pattern'] );
+			}
+		}
+
+		// Recursively normalize properties
+		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
+			foreach ( $schema['properties'] as $key => $property ) {
+				if ( is_array( $property ) ) {
+					$schema['properties'][ $key ] = $this->normalizeACFSchema( $property );
+				}
+			}
+		}
+
+		// Handle items in arrays
+		if ( isset( $schema['items'] ) && is_array( $schema['items'] ) ) {
+			$schema['items'] = $this->normalizeACFSchema( $schema['items'] );
+		}
+
+		// Handle oneOf, anyOf, allOf
+		foreach ( array( 'oneOf', 'anyOf', 'allOf' ) as $combiner ) {
+			if ( isset( $schema[ $combiner ] ) && is_array( $schema[ $combiner ] ) ) {
+				foreach ( $schema[ $combiner ] as $index => $subSchema ) {
+					if ( is_array( $subSchema ) ) {
+						$schema[ $combiner ][ $index ] = $this->normalizeACFSchema( $subSchema );
+					}
+				}
+			}
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Find a representative route for a given schema title
+	 *
+	 * @param string $schemaTitle The schema title from components
+	 * @return string|null A route that uses this schema, or null
+	 */
+	protected function findRouteForSchema( string $schemaTitle ): ?string {
+		$routes = $this->restServer->get_routes();
+
+		foreach ( $routes as $route => $handlers ) {
+			$options = $this->restServer->get_route_options( $route );
+			
+			if ( ! isset( $options['schema'] ) ) {
+				continue;
+			}
+
+			$schema = call_user_func( $options['schema'] );
+			
+			if ( isset( $schema['title'] ) ) {
+				$normalizedTitle = \WPOpenAPI\Util::normalizeSchemaTitle( $schema['title'] );
+				if ( $normalizedTitle === $schemaTitle ) {
+					// Return a concrete route without regex patterns if possible
+					// For routes with parameters, we need to find a concrete example
+					// For now, return the route as-is since we're doing OPTIONS
+					return $route;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Augment component schemas with ACF properties
+	 *
+	 * @param array $components The components array
+	 * @param array $args Additional arguments
+	 * @return array Modified components
+	 */
+	public function augmentComponentsWithACF( array $components, array $args = array() ): array {
+		if ( ! isset( $components['schemas'] ) || ! is_array( $components['schemas'] ) ) {
+			return $components;
+		}
+
+		foreach ( $components['schemas'] as $schemaTitle => $schema ) {
+			// Find a route that uses this schema
+			$route = $this->findRouteForSchema( $schemaTitle );
+			
+			if ( ! $route ) {
+				continue;
+			}
+
+			// Fetch ACF schema for this route
+			$acfSchema = $this->fetchACFSchema( $route );
+			
+			if ( ! $acfSchema ) {
+				continue;
+			}
+
+			// Ensure schema has properties key
+			if ( ! isset( $schema['properties'] ) ) {
+				$schema['properties'] = array();
+			}
+
+			// Add ACF property to the schema
+			$schema['properties']['acf'] = $acfSchema;
+
+			// Update the component schema
+			$components['schemas'][ $schemaTitle ] = $schema;
+		}
+
+		return $components;
+	}
+
+	/**
+	 * Augment operations with ACF properties in requestBody
+	 *
+	 * @param array $operations The operations array
+	 * @param array $args Additional arguments
+	 * @return array Modified operations
+	 */
+	public function augmentOperationsWithACF( array $operations, array $args = array() ): array {
+		foreach ( $operations as $operation ) {
+			$method   = $operation->getMethod();
+			$endpoint = $operation->getEndpoint();
+
+			// Only add ACF to write operations
+			if ( ! in_array( $method, array( 'post', 'put', 'patch' ), true ) ) {
+				continue;
+			}
+
+			// Fetch ACF schema for this endpoint
+			$acfSchema = $this->fetchACFSchema( $endpoint );
+			
+			if ( ! $acfSchema ) {
+				continue;
+			}
+
+			// Set ACF schema on the operation
+			$operation->setACFSchema( $acfSchema );
+		}
+
+		return $operations;
+	}
+}
+

--- a/src/Spec/Operation.php
+++ b/src/Spec/Operation.php
@@ -27,6 +27,7 @@ class Operation {
 	private array $responses                   = array();
 	private array $requestBodySchemaProperties = array();
 	private array $securities                  = array();
+	private ?array $acfSchema                  = null;
 
 	private array $jsonSchemaSets = array(
 		'oneOf'                => array( 'location' => 'root' ),
@@ -113,6 +114,16 @@ class Operation {
         $this->securities[] = (object) array( $name => $values );
     }
 
+	/**
+	 * Set ACF schema for this operation's request body
+	 *
+	 * @param array $acfSchema The ACF schema to add
+	 * @return void
+	 */
+	public function setACFSchema( array $acfSchema ): void {
+		$this->acfSchema = $acfSchema;
+	}
+
 	public function toArray(): array {
 		$data = array(
 			'responses' => array(),
@@ -151,11 +162,16 @@ class Operation {
             $data['security'] = $this->securities;
         }
 
-		if ( count( $this->requestBodySchemaProperties ) ) {
+		if ( count( $this->requestBodySchemaProperties ) || $this->acfSchema ) {
 			$schema = array(
 				'type'       => 'object',
 				'properties' => $this->requestBodySchemaProperties,
 			);
+
+			// Add ACF schema if present
+			if ( $this->acfSchema ) {
+				$schema['properties']['acf'] = $this->acfSchema;
+			}
 
 			$requiredProperties = array();
 			foreach ( $this->requestBodySchemaProperties as $name => $property ) {

--- a/wp-openapi.php
+++ b/wp-openapi.php
@@ -143,6 +143,7 @@ class WPOpenAPI {
 		}
 
 		new FixWPCoreCollectionEndpoints( $hooks );
+		new Filters\AddACFSchema( $hooks, $restServer );
 
 		$schemaGenerator = new SchemaGenerator( $hooks, $siteInfo, $restServer );
 		wp_send_json( $schemaGenerator->generate( $this->getNamespace() ) );


### PR DESCRIPTION
This PR adds support for Advanced Custom Fields (ACF) in the generated OpenAPI specification, making ACF fields discoverable and properly typed in the API documentation.

It makes it significantly easier to work with ACF fields through the REST API, especially when using typed API clients or automated code generation tools.

- Automatic ACF detection: the plugin now automatically detects and includes ACF field schemas from WordPress REST API endpoints
- Improved type safety: ACF schemas are normalized to ensure proper typing, with special handling for complex field types like clone fields and flexible content layouts

The integration fetches ACF schema information directly from WordPress REST API OPTIONS requests and merges it into the OpenAPI specification. This means:

- ACF fields appear in the `acf` property of resources
- Type definitions are accurate and match WordPress's native schema
- Client code generators (like `openapi-typescript` and `openapi-fetch`) can create proper types for ACF fields
- API consumers get full documentation of available ACF fields

About the technical changes:

- Added new `AddACFSchema` filter class to handle schema augmentation
- Extended `Operation` class to support ACF schema in request bodies
- Integrated the new filter into the main schema generation flow