### PR TITLE
Make ACF integration optional

### DIFF
--- a/resources/views/settings-acf-integration.php
+++ b/resources/views/settings-acf-integration.php
@@ -1,0 +1,1 @@
+<input type="checkbox" name="wp-openapi-options[enableACFIntegration]" <?php if($checked) {echo 'checked';} ?>/>

--- a/src/SettingsPage.php
+++ b/src/SettingsPage.php
@@ -48,6 +48,20 @@ class SettingsPage {
 		);
 	}
 
+	private function addACFIntegrationOption() {
+		add_settings_field(
+			'wp-openapi-settings-acf-integration',
+			'Enable ACF Integration',
+			function() {
+				$options = get_option( self::OPTION_ID );
+				$checked = isset( $options['enableACFIntegration'] ) && $options['enableACFIntegration'] === 'on';
+				echo ( new View( 'settings-acf-integration' ) )->render( array( 'checked' => $checked ) );
+			},
+			self::PAGE_ID,
+			$this->sectionId
+		);
+	}
+
 	private function initActions() {
 		add_action(
 			'plugin_action_links_wp-openapi/wp-openapi.php',
@@ -96,6 +110,7 @@ class SettingsPage {
 				add_settings_section( $this->sectionId, '', function(){}, self::PAGE_ID );
 				$this->addTryItOption();
 				$this->addDiscoveryOption();
+				$this->addACFIntegrationOption();
 			}
 		);
 	}

--- a/wp-openapi.php
+++ b/wp-openapi.php
@@ -143,7 +143,10 @@ class WPOpenAPI {
 		}
 
 		new FixWPCoreCollectionEndpoints( $hooks );
-		new Filters\AddACFSchema( $hooks, $restServer );
+
+		if ( SettingsPage::getOption( 'enableACFIntegration' ) === 'on' ) {
+			new Filters\AddACFSchema( $hooks, $restServer );
+		}
 
 		$schemaGenerator = new SchemaGenerator( $hooks, $siteInfo, $restServer );
 		wp_send_json( $schemaGenerator->generate( $this->getNamespace() ) );


### PR DESCRIPTION
Make https://github.com/moon0326/wp-openapi/pull/84 optional so that users can turn it on/off.

