### PR TITLE
Handle documentation of all responses

### DIFF
--- a/src/SchemaGenerator.php
+++ b/src/SchemaGenerator.php
@@ -77,8 +77,21 @@ class SchemaGenerator {
 						$base['components']['schemas'][ $schemaTitle ] = $schema;
 					}
 				}
+				// Extract responses from route options if available
+				// WordPress stores route-level options (like 'schema' and 'responses') in route options
+				$routeResponses = isset( $options['responses'] ) ? $options['responses'] : null;
+				// Also check if responses are in the args structure as a fallback
+				if ( ! $routeResponses && is_array( $args ) ) {
+					// Check if responses is in the last element (route-level options are usually appended)
+					foreach ( $args as $arg ) {
+						if ( isset( $arg['responses'] ) && is_array( $arg['responses'] ) ) {
+							$routeResponses = $arg['responses'];
+							break;
+						}
+					}
+				}
 				$path = new Path( $path, $schemaTitle );
-				$path->generateOperationsFromRouteArgs( $args );
+				$path->generateOperationsFromRouteArgs( $args, $routeResponses );
 				$paths[ $path->getPath() ] = $path;
 			}
 		}

--- a/src/Spec/Response.php
+++ b/src/Spec/Response.php
@@ -39,6 +39,9 @@ class Response {
 		if ( count( $this->contents ) ) {
 			foreach ( $this->contents as $content ) {
 				$data['content'][ $content->getMediaType() ]['schema'] = $content->getSchema();
+				if ( $content->getExample() !== null ) {
+					$data['content'][ $content->getMediaType() ]['example'] = $content->getExample();
+				}
 			}
 		}
 

--- a/src/Spec/ResponseContent.php
+++ b/src/Spec/ResponseContent.php
@@ -9,10 +9,12 @@ class ResponseContent {
 	 * @var array
 	 */
 	private array $schema;
+	private $example = null;
 
-	public function __construct( $mediaType, array $schema ) {
+	public function __construct( $mediaType, array $schema, $example = null ) {
 		$this->mediaType = $mediaType;
 		$this->schema    = $schema;
+		$this->example   = $example;
 	}
 
 	public function getMediaType(): string {
@@ -21,5 +23,9 @@ class ResponseContent {
 
 	public function getSchema(): array {
 		return $this->schema;
+	}
+
+	public function getExample() {
+		return $this->example;
 	}
 }


### PR DESCRIPTION
## 📘 Documenting API Responses

Now all responses can be documented using the following structure:

### ✅ Usage

```php
'responses' => [
    200 => [
        'description' => 'Successful response',
        'content' => [
            'application/json' => [
                'schema' => [
                    // Define your schema here
                ]
            ]
        ]
    ],
    400 => [
        'description' => 'Bad request',
        'content' => [
            'application/json' => [
                'schema' => [
                    // Define error schema here
                ]
            ]
        ]
    ]
]
```

### ✅ Preview output
![Screenshot 2025-10-31 035931](https://github.com/user-attachments/assets/7291b1cd-3bfc-4c58-8f46-931419e305e8)
