### PR TITLE
add hyphen to acceptable schema title characters

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -73,7 +73,7 @@ class Util {
 	public static function normalizeSchemaTitle( $title ) {
 		// Remove invalid characters for schema titles.
 		// Only allow alphanumeric characters and underscores.
-		$title = preg_replace( '/[^a-zA-Z0-9_]/', '_', $title );
+		$title = preg_replace( '/[^a-zA-Z0-9_-]/', '_', $title );
 		// Ensure the title starts with an alphabetic character or underscore.
 		if ( ! preg_match( '/^[a-zA-Z_]/', $title ) ) {
 			$title = '_' . $title;


### PR DESCRIPTION
A dirty fix for https://github.com/moon0326/wp-openapi/issues/90 but not for the potential underlying issue.